### PR TITLE
Disambiguate this project from others named zuul

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,14 @@
 Zuul is an edge service that provides dynamic routing, monitoring, resiliency, security, and more.
 Please view the wiki for usage, information, HOWTO, etc https://github.com/Netflix/zuul/wiki
 
+If you are looking for the OpenStack related test automation tool that is also named Zuul, you can find it here:
+
+https://docs.openstack.org/infra/zuul/
+
+If you are looking for the javascript testing tool named Zuul, you can find it here:
+
+https://github.com/defunctzombie/zuul
+
 Here are some links to help you learn more about the Zuul Project. Feel free to PR to add any other info, presentations, etc.
 
 ---


### PR DESCRIPTION
There are at least two projects named Zuul that are not this one. Provide links in the README for anyone who has stumbled into the wrong Github.

Closes #49